### PR TITLE
Fix for header being stripped out

### DIFF
--- a/responseWriterWrapper.go
+++ b/responseWriterWrapper.go
@@ -136,7 +136,7 @@ func (instance *responseWriterWrapper) writeHeadersToDelegate(defStatus int) err
 	w := instance.delegate
 	for key, values := range instance.header {
 		for _, value := range values {
-			w.Header().Set(key, value)
+			w.Header().Add(key, value)
 		}
 	}
 	w.WriteHeader(instance.selectStatus(defStatus))

--- a/responseWriterWrapper.go
+++ b/responseWriterWrapper.go
@@ -17,7 +17,7 @@ func newResponseWriterWrapperFor(delegate http.ResponseWriter, beforeFirstWrite 
 		statusSetAtDelegate: 0,
 		bodyAllowed:         true,
 		maximumBufferSize:   -1,
-		header:              delegate.Header(),
+		header:              http.Header{},
 	}
 }
 


### PR DESCRIPTION
Currently multiple Set-Cookie headers for example are getting stripped.
Test below. Visit on port 81 and notice you get multiple set-cookie headers. Now visit on port 80 and notice you only see one. This PR fixes this bug.

**Caddyfile**
```Caddyfile
http://localhost:80 {
	proxy / http://localhost:81
	filter rule {
		content_type text\/html.*
		search_pattern World
		replacement Other
	}
}

http://localhost:81 {
	root ./
	header / +set-cookie a=x
	header / +set-cookie b=y
	header / +set-cookie c=z
}
```

**index.html**
```html
<html><h1>Hello World</h1></html>
```