### PR TITLE
Fixed CI build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.echocat.gradle.plugins.golang.utils.Executor
 import static org.echocat.gradle.plugins.golang.model.Platform.currentPlatform
 
 plugins {
-    id 'org.echocat.golang' version '0.1.11'
+    id 'org.echocat.golang' version '0.1.16'
 }
 
 group 'github.com/echocat/caddy-filter'
@@ -12,7 +12,7 @@ golang {
     // For testing only the current platform is required.
     platforms = currentPlatform()
     dependencies {
-        build 'github.com/mholt/caddy:v0.9.5'
+        build 'github.com/mholt/caddy:v0.10.4'
         test 'github.com/stretchr/testify'
         tool 'github.com/mattn/goveralls'
     }
@@ -22,6 +22,9 @@ golang {
     testing {
         coverProfile = "${buildDir}/testing/${name}.cover"
         coverProfileHtml = "${buildDir}/testing/${name}.cover.html"
+    }
+    toolchain {
+        goversion = 'go1.8'
     }
 }
 

--- a/responseWriterWrapper.go
+++ b/responseWriterWrapper.go
@@ -10,8 +10,8 @@ import (
 )
 
 func newResponseWriterWrapperFor(delegate http.ResponseWriter, beforeFirstWrite func(*responseWriterWrapper) bool) *responseWriterWrapper {
-	return &responseWriterWrapper{
-		skipped:    false,
+	wrapper := &responseWriterWrapper{
+		skipped:             false,
 		delegate:            delegate,
 		beforeFirstWrite:    beforeFirstWrite,
 		statusSetAtDelegate: 0,
@@ -19,6 +19,12 @@ func newResponseWriterWrapperFor(delegate http.ResponseWriter, beforeFirstWrite 
 		maximumBufferSize:   -1,
 		header:              http.Header{},
 	}
+	for key, values := range delegate.header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	return wrapper
 }
 
 type responseWriterWrapper struct {


### PR DESCRIPTION
The previous build issues were caused by the fact TLS config was updated in golang v1.8 which is what one of the dependencies required.

At the same time I've updated the version of the plugin you created and changed caddy dependency to the most recent version.

Also fixed test failure.